### PR TITLE
fix: update price label formatting

### DIFF
--- a/src/features/signup-form/select-plan/subscription-option.test.tsx
+++ b/src/features/signup-form/select-plan/subscription-option.test.tsx
@@ -153,7 +153,7 @@ describe('SubscriptionOption', () => {
     expect(radio).toHaveAttribute('value', 'pro');
     expect(radio).toBeRequired();
 
-    expect(radio).toHaveAccessibleDescription('$120.00/yr');
+    expect(radio).toHaveAccessibleDescription('$120/yr');
   });
 
   it('renders yearly bonuses when billing is Yearly and hides them for Monthly billing', () => {
@@ -165,7 +165,7 @@ describe('SubscriptionOption', () => {
       description: { billingPeriod: 'Yearly', price: 60, bonuses: ['Bonus A', 'Bonus B'] },
     });
 
-    expect(screen.getByText('$60.00/yr')).toBeInTheDocument();
+    expect(screen.getByText('$60/yr')).toBeInTheDocument();
     expect(screen.getByText('Bonus A')).toBeInTheDocument();
     expect(screen.getByText('Bonus B')).toBeInTheDocument();
 
@@ -181,7 +181,7 @@ describe('SubscriptionOption', () => {
       />,
     );
 
-    expect(screen.getByText('$15.00/mo')).toBeInTheDocument();
+    expect(screen.getByText('$15/mo')).toBeInTheDocument();
     expect(screen.queryByText('Bonus A')).not.toBeInTheDocument();
     expect(screen.queryByText('Bonus B')).not.toBeInTheDocument();
   });

--- a/src/features/signup-form/utils.test.ts
+++ b/src/features/signup-form/utils.test.ts
@@ -3,27 +3,27 @@ import { getPriceLabel, type BillingPeriod } from './utils';
 
 describe('getPriceLabel', () => {
   it('formats Monthly amounts with the default "/mo" suffix', () => {
-    expect(getPriceLabel({ amount: 15, billingPeriod: 'Monthly' })).toBe('$15.00/mo');
+    expect(getPriceLabel({ amount: 15, billingPeriod: 'Monthly' })).toBe('$15/mo');
   });
 
   it('formats Yearly amounts with the default "/yr" suffix', () => {
-    expect(getPriceLabel({ amount: 120, billingPeriod: 'Yearly' })).toBe('$120.00/yr');
+    expect(getPriceLabel({ amount: 120, billingPeriod: 'Yearly' })).toBe('$120/yr');
   });
 
   it('uses the provided suffixes mapping when passed', () => {
     const suffixes: Record<BillingPeriod, string> = { Monthly: 'mth', Yearly: 'year' };
 
-    expect(getPriceLabel({ amount: 15, billingPeriod: 'Monthly', suffixes })).toBe('$15.00/mth');
-    expect(getPriceLabel({ amount: 120, billingPeriod: 'Yearly', suffixes })).toBe('$120.00/year');
+    expect(getPriceLabel({ amount: 15, billingPeriod: 'Monthly', suffixes })).toBe('$15/mth');
+    expect(getPriceLabel({ amount: 120, billingPeriod: 'Yearly', suffixes })).toBe('$120/year');
   });
 
-  it('rounds amounts to 2 decimal places', () => {
-    expect(getPriceLabel({ amount: 9.999, billingPeriod: 'Monthly' })).toBe('$10.00/mo');
+  it('renders amounts as-is without rounding or fixed decimals', () => {
+    expect(getPriceLabel({ amount: 9.999, billingPeriod: 'Monthly' })).toBe('$9.999/mo');
   });
 
   it('allows overriding the currency symbol', () => {
     expect(getPriceLabel({ amount: 15, billingPeriod: 'Monthly', currencySymbol: '€' })).toBe(
-      '€15.00/mo',
+      '€15/mo',
     );
   });
 });

--- a/src/features/signup-form/utils.ts
+++ b/src/features/signup-form/utils.ts
@@ -17,6 +17,5 @@ export function getPriceLabel({
   currencySymbol?: string;
 }): string {
   const suffix = suffixes[billingPeriod];
-  const formattedAmount = amount.toFixed(2);
-  return `${currencySymbol}${formattedAmount}/${suffix}`;
+  return `${currencySymbol}${amount}/${suffix}`;
 }


### PR DESCRIPTION
## 📌 Description

Update the `getPriceLabel` function to display prices as it is, no need to force 2 decimal spaces. Closes #7.

---

## 🔧 Changes Made

- Updated `getPriceLabel` function.
- Updated `utils.test.ts` and `subscription-option.test.tsx`.

---

## 🧪 How to Test

1. Pull this branch.
2. Run tests: `bun run test`
3. Confirm that all the tests pass.
4. Run the application.
5. Observe the subscription option radio buttons in the 2nd step of signup form (select plan).
6. Confirm that the prices are displayed without 2 decimal space restriction.
7. (Optionally) Try passing different values for `description.price` prop of `SubscriptionOption` component.

---

## 📷 Screenshots (if applicable)

<img width="295" height="411" alt="" src="https://github.com/user-attachments/assets/d467ee80-87d2-45fa-9a88-47a112faadff" />

---

## ✅ Checklist

- [x] Code compiles and runs
- [x] Tested locally