### PR TITLE
Feature/21 slot summary

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -232,6 +232,16 @@ export default function App() {
               { name: 'Larger storage', price: 20 },
             ]}
             onSubscriptionChange={() => {}}
+            footer={
+              <div className="flex items-center justify-between">
+                <button type="button" className="btn-ghost">
+                  Go Back
+                </button>
+                <button type="submit" className="btn-primary">
+                  Confirm
+                </button>
+              </div>
+            }
           />
         </SignupForm>
 

--- a/src/features/signup-form/summary/summary.test.tsx
+++ b/src/features/signup-form/summary/summary.test.tsx
@@ -1,10 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import type { ComponentProps } from 'react';
-import Summary from './summary';
-
-type SummaryProps = ComponentProps<typeof Summary>;
+import Summary, { type SummaryProps } from './summary';
 
 const defaultProps: SummaryProps = {
   subscription: {
@@ -17,6 +14,7 @@ const defaultProps: SummaryProps = {
     { name: 'Larger storage', price: 3 },
   ],
   onSubscriptionChange: vi.fn(),
+  footer: <div>Test footer content</div>,
 };
 
 function renderSummary(overrides: Partial<SummaryProps> = {}) {
@@ -164,22 +162,18 @@ describe('Summary', () => {
       expect(screen.getByRole('list', { name: /add-ons/i })).toBeInTheDocument();
     });
 
-    it('renders action buttons with accessible names', () => {
-      renderSummary();
+    it('renders footer content when provided', () => {
+      renderSummary({
+        footer: (
+          <div>
+            <button>Go Back</button>
+            <button>Confirm</button>
+          </div>
+        ),
+      });
 
-      const actionsContainer = screen.getByRole('button', { name: /confirm/i }).closest('div');
-
-      expect(
-        within(actionsContainer!).getByRole('button', {
-          name: /go back/i,
-        }),
-      ).toBeInTheDocument();
-
-      expect(
-        within(actionsContainer!).getByRole('button', {
-          name: /confirm/i,
-        }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /go back/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument();
     });
   });
 });

--- a/src/features/signup-form/summary/summary.tsx
+++ b/src/features/signup-form/summary/summary.tsx
@@ -1,12 +1,19 @@
+import type { ReactNode } from 'react';
 import { calculateTotalPrice, getPriceLabel, type BillingPeriod } from '../utils';
 
-type Props = {
+export type SummaryProps = {
   subscription: { name: string; billingPeriod: BillingPeriod; price: number };
   addOns: { name: string; price: number }[];
   onSubscriptionChange: () => void;
+  footer: ReactNode;
 };
 
-export default function Summary({ subscription, addOns, onSubscriptionChange }: Props) {
+export default function Summary({
+  subscription,
+  addOns,
+  onSubscriptionChange,
+  footer,
+}: SummaryProps) {
   const addOnsList = addOns.map((addOn) => (
     <li className="flex items-center justify-between">
       <span className="text-black/45">{addOn.name}</span>
@@ -62,14 +69,7 @@ export default function Summary({ subscription, addOns, onSubscriptionChange }: 
         </p>
       </div>
 
-      <div className="flex items-center justify-between">
-        <button type="button" className="btn-ghost">
-          Go Back
-        </button>
-        <button type="submit" className="btn-primary">
-          Confirm
-        </button>
-      </div>
+      {footer}
     </section>
   );
 }


### PR DESCRIPTION
## 📌 Description

Pass form control buttons to `Summary` via slots. Closes #21.

---

## 🔧 Changes Made

- Refactored `Summary` to accept footer slot.
- Exported `SummaryProps`.

---

## 🧪 How to Test

1. Pull this branch.
2. Run the tests: `bun run test`.
3. Run the application.
4. "Summary" form-step should look no different.

---

## ✅ Checklist

- [X] Code compiles and runs
- [X] Tested locally