### PR TITLE
Feature/23 progress step rename state

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -148,7 +148,7 @@ export default function App() {
       <SignupProgress>
         <ProgressStep status={{ kind: 'Completed', description: 'Completed' }} title="Your info" />
         <ProgressStep
-          status={{ kind: 'Current', description: 'Current step' }}
+          status={{ kind: 'Started', description: 'Current step' }}
           title="Select plan"
         />
         <ProgressStep status={{ kind: 'NotStarted', description: 'Not started' }} title="Add-ons" />

--- a/src/features/signup-progress/progress-step.test.tsx
+++ b/src/features/signup-progress/progress-step.test.tsx
@@ -20,20 +20,20 @@ describe('ProgressStep', () => {
     expect(step).toHaveAccessibleDescription('Step not started yet');
   });
 
-  it('marks the current step using aria-current', () => {
+  it('marks the started step using aria-current', () => {
     render(
       <ProgressStep
-        title="Current step"
-        status={{ kind: 'Current', description: 'Current description' }}
+        title="Started step"
+        status={{ kind: 'Started', description: 'Started description' }}
       />,
     );
 
-    const currentStep = screen.getByRole('listitem', {
-      name: /current step/i,
+    const startedStep = screen.getByRole('listitem', {
+      name: /started step/i,
       current: 'step',
     });
 
-    expect(currentStep).toBeInTheDocument();
+    expect(startedStep).toBeInTheDocument();
   });
 
   it('does not mark non-current steps as current', () => {
@@ -60,7 +60,7 @@ describe('ProgressStep', () => {
     expect(step).not.toHaveAttribute('aria-current');
 
     rerender(
-      <ProgressStep title="Step" status={{ kind: 'Current', description: 'Now current' }} />,
+      <ProgressStep title="Step" status={{ kind: 'Started', description: 'Now started' }} />,
     );
 
     step = screen.getByRole('listitem', {

--- a/src/features/signup-progress/progress-step.tsx
+++ b/src/features/signup-progress/progress-step.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 type Props = {
   title: string;
   status: {
-    kind: 'NotStarted' | 'Current' | 'Completed';
+    kind: 'NotStarted' | 'Started' | 'Completed';
     description: string;
   };
 };
@@ -15,7 +15,7 @@ export default function ProgressStep({ title, status }: Props) {
 
   return (
     <li
-      aria-current={status.kind === 'Current' ? 'step' : undefined}
+      aria-current={status.kind === 'Started' ? 'step' : undefined}
       aria-labelledby={titleId}
       aria-describedby={descId}
       data-progress-step={status.kind}
@@ -23,7 +23,7 @@ export default function ProgressStep({ title, status }: Props) {
     >
       <p
         id={titleId}
-        className={clsx('sr-only sm:not-sr-only', status.kind != 'Current' && 'sm:text-black/45')}
+        className={clsx('sr-only sm:not-sr-only', status.kind !== 'Started' && 'sm:text-black/45')}
       >
         {title}
       </p>

--- a/src/index.css
+++ b/src/index.css
@@ -23,7 +23,7 @@
     @apply border-dotted border-yellow-400 bg-yellow-600;
   }
 
-  [data-progress-step='Current']::before {
+  [data-progress-step='Started']::before {
     @apply border-cyan-400 bg-cyan-600;
   }
 


### PR DESCRIPTION
## 📌 Description

`ProgressStep` component can be in one of three states: `Completed` | `Current` | `NotStarted`.

Change the name of Current state.

Closes #23.

---

## 🔧 Changes Made

- Renamed `ProgressStep` status kind `Current` to `Started`.
- Updated `data-progress-step` selector to use `Started` instead of `Current`.
- Updated tests to use `Started` instead of `Current`.

---

## 🧪 How to Test

1. Pull this branch.
2. Run tests: `bun run test`.
3. Run the application.
4. Progress steps should look no different.

---

## ✅ Checklist

- [X] Code compiles and runs
- [X] Tested locally