### PR TITLE
Feature/27 form progress state

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@fontsource/ubuntu": "^5.2.8",
         "@tailwindcss/vite": "^4.2.2",
+        "@xstate/react": "^6.1.0",
         "clsx": "^2.1.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
@@ -14,6 +15,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "tailwindcss": "^4.2.2",
+        "xstate": "^5.30.0",
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -345,6 +347,8 @@
     "@vitest/spy": ["@vitest/spy@4.1.0", "", {}, "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw=="],
 
     "@vitest/utils": ["@vitest/utils@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw=="],
+
+    "@xstate/react": ["@xstate/react@6.1.0", "", { "dependencies": { "use-isomorphic-layout-effect": "^1.1.2", "use-sync-external-store": "^1.2.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "xstate": "^5.28.0" }, "optionalPeers": ["xstate"] }, "sha512-ep9F0jGTI63B/jE8GHdMpUqtuz7yRebNaKv8EMUaiSi29NOglywc2X2YSOV/ygbIK+LtmgZ0q9anoEA2iBSEOw=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -688,6 +692,10 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "use-isomorphic-layout-effect": ["use-isomorphic-layout-effect@1.2.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "vitest": ["vitest@4.1.0", "", { "dependencies": { "@vitest/expect": "4.1.0", "@vitest/mocker": "4.1.0", "@vitest/pretty-format": "4.1.0", "@vitest/runner": "4.1.0", "@vitest/snapshot": "4.1.0", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.0", "@vitest/browser-preview": "4.1.0", "@vitest/browser-webdriverio": "4.1.0", "@vitest/ui": "4.1.0", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw=="],
@@ -709,6 +717,8 @@
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "xstate": ["xstate@5.30.0", "", {}, "sha512-mIzIuMjtYVkqXq9dUzYQoag7b/dF1CBS/yhliuPLfR0FwKPC18HiUivb/crcqY2gknhR8gJEhnppLg6ubQ0gGw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
   "dependencies": {
     "@fontsource/ubuntu": "^5.2.8",
     "@tailwindcss/vite": "^4.2.2",
+    "@xstate/react": "^6.1.0",
     "clsx": "^2.1.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "prettier": "^3.8.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "tailwindcss": "^4.2.2"
+    "tailwindcss": "^4.2.2",
+    "xstate": "^5.30.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,17 +15,19 @@ import SubscriptionOption from './features/signup-form/select-plan/subscription-
 import type { AddOnsOptionProps } from './features/signup-form/add-ons/add-ons-option';
 import AddOnsOption from './features/signup-form/add-ons/add-ons-option';
 import { useMachine } from '@xstate/react';
-import { formProgressMachine } from './features/state/form-progress-state';
+import { formProgressMachine, formSteps } from './features/state/form-progress-state';
 
 export default function App() {
   const [snapshot, send] = useMachine(formProgressMachine);
 
-  const progressStepConfigs: ProgressStepProps[] = [
-    { title: 'Your info', status: { kind: 'Completed', description: 'Completed' } },
-    { title: 'Select plan', status: { kind: 'Started', description: 'Started' } },
-    { title: 'Add-ons', status: { kind: 'NotStarted', description: 'Not started' } },
-    { title: 'Summary', status: { kind: 'NotStarted', description: 'Not started' } },
-  ];
+  const progressStepConfigs: ProgressStepProps[] = Object.entries(
+    snapshot.context.statusRecord,
+  ).map(function ([stepId, stepStatus]) {
+    return {
+      title: formSteps[stepId].title,
+      status: { kind: stepStatus, description: 'sample description' },
+    };
+  });
 
   const infoInputConfigs: InfoInputProps[] = [
     {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,7 +15,11 @@ import SubscriptionOption from './features/signup-form/select-plan/subscription-
 import type { AddOnsOptionProps } from './features/signup-form/add-ons/add-ons-option';
 import AddOnsOption from './features/signup-form/add-ons/add-ons-option';
 import { useMachine } from '@xstate/react';
-import { formProgressMachine, formSteps } from './features/state/form-progress-state';
+import {
+  formProgressMachine,
+  formSteps,
+  formStepStatusDescriptions,
+} from './features/state/form-progress-state';
 
 export default function App() {
   const [snapshot, send] = useMachine(formProgressMachine);
@@ -25,7 +29,7 @@ export default function App() {
   ).map(function ([stepId, stepStatus]) {
     return {
       title: formSteps[stepId].title,
-      status: { kind: stepStatus, description: 'sample description' },
+      status: { kind: stepStatus, description: formStepStatusDescriptions[stepStatus] },
     };
   });
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,8 +14,12 @@ import type { SubscriptionOptionProps } from './features/signup-form/select-plan
 import SubscriptionOption from './features/signup-form/select-plan/subscription-option';
 import type { AddOnsOptionProps } from './features/signup-form/add-ons/add-ons-option';
 import AddOnsOption from './features/signup-form/add-ons/add-ons-option';
+import { useMachine } from '@xstate/react';
+import { formProgressMachine } from './features/state/form-progress-state';
 
 export default function App() {
+  const [snapshot, send] = useMachine(formProgressMachine);
+
   const progressStepConfigs: ProgressStepProps[] = [
     { title: 'Your info', status: { kind: 'Completed', description: 'Completed' } },
     { title: 'Select plan', status: { kind: 'Started', description: 'Started' } },
@@ -159,96 +163,134 @@ export default function App() {
       </SignupProgress>
 
       <main>
-        <SignupForm>
-          <YourInfo
-            inputs={
-              <>
-                {infoInputConfigs.map(function (config) {
-                  const key = `input-${config.name}`;
-                  return <InfoInput key={key} {...config} />;
-                })}
-              </>
-            }
-            footer={
-              <div className="flex items-center justify-end">
-                <button type="button" className="btn-primary">
-                  Next Step
-                </button>
-              </div>
-            }
-          />
+        {snapshot.hasTag('confirmation') ? (
+          <ConfirmationMessage />
+        ) : (
+          <SignupForm>
+            {snapshot.hasTag('yourInfo') && (
+              <YourInfo
+                inputs={
+                  <>
+                    {infoInputConfigs.map(function (config) {
+                      const key = `input-${config.name}`;
+                      return <InfoInput key={key} {...config} />;
+                    })}
+                  </>
+                }
+                footer={
+                  <div className="flex items-center justify-end">
+                    <button
+                      type="button"
+                      className="btn-primary"
+                      onClick={() => send({ type: 'YOUR_INFO.NEXT', isInfoValid: true })}
+                    >
+                      Next Step
+                    </button>
+                  </div>
+                }
+              />
+            )}
 
-          <SelectPlan
-            billingOptions={
-              <>
-                {billingOptionConfigs.map(function (config) {
-                  const key = `billing-${config.value}`;
-                  return <BillingOption key={key} {...config} />;
-                })}
-              </>
-            }
-            subscriptionOptions={
-              <>
-                {subscriptionOptionConfigs.map(function (config) {
-                  const key = `subscription-${config.value}`;
-                  return <SubscriptionOption key={key} {...config} />;
-                })}
-              </>
-            }
-            footer={
-              <div className="flex items-center justify-between">
-                <button type="button" className="btn-ghost">
-                  Go Back
-                </button>
-                <button type="button" className="btn-primary">
-                  Next Step
-                </button>
-              </div>
-            }
-          />
+            {snapshot.hasTag('selectPlan') && (
+              <SelectPlan
+                billingOptions={
+                  <>
+                    {billingOptionConfigs.map(function (config) {
+                      const key = `billing-${config.value}`;
+                      return <BillingOption key={key} {...config} />;
+                    })}
+                  </>
+                }
+                subscriptionOptions={
+                  <>
+                    {subscriptionOptionConfigs.map(function (config) {
+                      const key = `subscription-${config.value}`;
+                      return <SubscriptionOption key={key} {...config} />;
+                    })}
+                  </>
+                }
+                footer={
+                  <div className="flex items-center justify-between">
+                    <button
+                      type="button"
+                      className="btn-ghost"
+                      onClick={() => send({ type: 'SELECT_PLAN.BACK' })}
+                    >
+                      Go Back
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-primary"
+                      onClick={() => send({ type: 'SELECT_PLAN.NEXT' })}
+                    >
+                      Next Step
+                    </button>
+                  </div>
+                }
+              />
+            )}
 
-          <AddOns
-            options={
-              <>
-                {addOnsOptionConfigs.map(function (config) {
-                  const key = `add-ons-${config.value}`;
-                  return <AddOnsOption key={key} {...config} />;
-                })}
-              </>
-            }
-            footer={
-              <div className="flex items-center justify-between">
-                <button type="button" className="btn-ghost">
-                  Go Back
-                </button>
-                <button type="button" className="btn-primary">
-                  Next Step
-                </button>
-              </div>
-            }
-          />
+            {snapshot.hasTag('addOns') && (
+              <AddOns
+                options={
+                  <>
+                    {addOnsOptionConfigs.map(function (config) {
+                      const key = `add-ons-${config.value}`;
+                      return <AddOnsOption key={key} {...config} />;
+                    })}
+                  </>
+                }
+                footer={
+                  <div className="flex items-center justify-between">
+                    <button
+                      type="button"
+                      className="btn-ghost"
+                      onClick={() => send({ type: 'ADD_ONS.BACK' })}
+                    >
+                      Go Back
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-primary"
+                      onClick={() => send({ type: 'ADD_ONS.NEXT' })}
+                    >
+                      Next Step
+                    </button>
+                  </div>
+                }
+              />
+            )}
 
-          <Summary
-            subscription={{ name: 'Arcade', billingPeriod: 'Yearly', price: 90 }}
-            addOns={[
-              { name: 'Online service', price: 10 },
-              { name: 'Larger storage', price: 20 },
-            ]}
-            onSubscriptionChange={() => {}}
-            footer={
-              <div className="flex items-center justify-between">
-                <button type="button" className="btn-ghost">
-                  Go Back
-                </button>
-                <button type="submit" className="btn-primary">
-                  Confirm
-                </button>
-              </div>
-            }
-          />
-        </SignupForm>
-
-        <ConfirmationMessage />
+            {snapshot.hasTag('summary') && (
+              <Summary
+                subscription={{ name: 'Arcade', billingPeriod: 'Yearly', price: 90 }}
+                addOns={[
+                  { name: 'Online service', price: 10 },
+                  { name: 'Larger storage', price: 20 },
+                ]}
+                onSubscriptionChange={() => send({ type: 'SUMMARY.CHANGE_SUBSCRIPTION' })}
+                footer={
+                  <div className="flex items-center justify-between">
+                    <button
+                      type="button"
+                      className="btn-ghost"
+                      onClick={() => send({ type: 'SUMMARY.BACK' })}
+                    >
+                      Go Back
+                    </button>
+                    <button
+                      type="submit"
+                      className="btn-primary"
+                      onClick={() => send({ type: 'SUMMARY.NEXT' })}
+                    >
+                      Confirm
+                    </button>
+                  </div>
+                }
+              />
+            )}
+          </SignupForm>
+        )}
       </main>
     </div>
   );

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,18 +14,14 @@ import type { SubscriptionOptionProps } from './features/signup-form/select-plan
 import SubscriptionOption from './features/signup-form/select-plan/subscription-option';
 import type { AddOnsOptionProps } from './features/signup-form/add-ons/add-ons-option';
 import AddOnsOption from './features/signup-form/add-ons/add-ons-option';
-import { useMachine } from '@xstate/react';
-import {
-  formProgressMachine,
-  formSteps,
-  formStepStatusDescriptions,
-} from './features/state/form-progress-state';
+import { formSteps, formStepStatusDescriptions } from './features/state/form-progress-state';
+import { useFormProgressMachine } from './features/hooks/use-form-progress-machine';
 
 export default function App() {
-  const [snapshot, send] = useMachine(formProgressMachine);
+  const formProgressActor = useFormProgressMachine();
 
   const progressStepConfigs: ProgressStepProps[] = Object.entries(
-    snapshot.context.statusRecord,
+    formProgressActor.snapshot.context.statusRecord,
   ).map(function ([stepId, stepStatus]) {
     return {
       title: formSteps[stepId].title,
@@ -169,11 +165,11 @@ export default function App() {
       </SignupProgress>
 
       <main>
-        {snapshot.hasTag('confirmation') ? (
+        {formProgressActor.snapshot.hasTag('confirmation') ? (
           <ConfirmationMessage />
         ) : (
           <SignupForm>
-            {snapshot.hasTag('yourInfo') && (
+            {formProgressActor.snapshot.hasTag('yourInfo') && (
               <YourInfo
                 inputs={
                   <>
@@ -188,7 +184,9 @@ export default function App() {
                     <button
                       type="button"
                       className="btn-primary"
-                      onClick={() => send({ type: 'YOUR_INFO.NEXT', isInfoValid: true })}
+                      onClick={() =>
+                        formProgressActor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: true })
+                      }
                     >
                       Next Step
                     </button>
@@ -197,7 +195,7 @@ export default function App() {
               />
             )}
 
-            {snapshot.hasTag('selectPlan') && (
+            {formProgressActor.snapshot.hasTag('selectPlan') && (
               <SelectPlan
                 billingOptions={
                   <>
@@ -220,14 +218,14 @@ export default function App() {
                     <button
                       type="button"
                       className="btn-ghost"
-                      onClick={() => send({ type: 'SELECT_PLAN.BACK' })}
+                      onClick={() => formProgressActor.send({ type: 'SELECT_PLAN.BACK' })}
                     >
                       Go Back
                     </button>
                     <button
                       type="button"
                       className="btn-primary"
-                      onClick={() => send({ type: 'SELECT_PLAN.NEXT' })}
+                      onClick={() => formProgressActor.send({ type: 'SELECT_PLAN.NEXT' })}
                     >
                       Next Step
                     </button>
@@ -236,7 +234,7 @@ export default function App() {
               />
             )}
 
-            {snapshot.hasTag('addOns') && (
+            {formProgressActor.snapshot.hasTag('addOns') && (
               <AddOns
                 options={
                   <>
@@ -251,14 +249,14 @@ export default function App() {
                     <button
                       type="button"
                       className="btn-ghost"
-                      onClick={() => send({ type: 'ADD_ONS.BACK' })}
+                      onClick={() => formProgressActor.send({ type: 'ADD_ONS.BACK' })}
                     >
                       Go Back
                     </button>
                     <button
                       type="button"
                       className="btn-primary"
-                      onClick={() => send({ type: 'ADD_ONS.NEXT' })}
+                      onClick={() => formProgressActor.send({ type: 'ADD_ONS.NEXT' })}
                     >
                       Next Step
                     </button>
@@ -267,27 +265,29 @@ export default function App() {
               />
             )}
 
-            {snapshot.hasTag('summary') && (
+            {formProgressActor.snapshot.hasTag('summary') && (
               <Summary
                 subscription={{ name: 'Arcade', billingPeriod: 'Yearly', price: 90 }}
                 addOns={[
                   { name: 'Online service', price: 10 },
                   { name: 'Larger storage', price: 20 },
                 ]}
-                onSubscriptionChange={() => send({ type: 'SUMMARY.CHANGE_SUBSCRIPTION' })}
+                onSubscriptionChange={() =>
+                  formProgressActor.send({ type: 'SUMMARY.CHANGE_SUBSCRIPTION' })
+                }
                 footer={
                   <div className="flex items-center justify-between">
                     <button
                       type="button"
                       className="btn-ghost"
-                      onClick={() => send({ type: 'SUMMARY.BACK' })}
+                      onClick={() => formProgressActor.send({ type: 'SUMMARY.BACK' })}
                     >
                       Go Back
                     </button>
                     <button
                       type="submit"
                       className="btn-primary"
-                      onClick={() => send({ type: 'SUMMARY.NEXT' })}
+                      onClick={() => formProgressActor.send({ type: 'SUMMARY.NEXT' })}
                     >
                       Confirm
                     </button>

--- a/src/features/confirmation/confirmation-message.tsx
+++ b/src/features/confirmation/confirmation-message.tsx
@@ -1,4 +1,8 @@
+import { useTitleFocus } from '../hooks/use-title-focus';
+
 export default function ConfirmationMessage() {
+  const titleRefCallback = useTitleFocus<HTMLHeadingElement>();
+
   return (
     <section
       aria-label="Subscription confirmed"
@@ -20,7 +24,9 @@ export default function ConfirmationMessage() {
         />
       </svg>
 
-      <h2 className="text-xl">Thank you!</h2>
+      <h2 tabIndex={-1} className="text-xl outline-none" ref={titleRefCallback}>
+        Thank you!
+      </h2>
 
       <p className="max-w-[60ch]">
         Thanks for confirming your subscription! We hope you have fun using our platform. If you

--- a/src/features/hooks/use-form-progress-machine.ts
+++ b/src/features/hooks/use-form-progress-machine.ts
@@ -1,0 +1,7 @@
+import { useMachine } from '@xstate/react';
+import { formProgressMachine } from '../state/form-progress-state';
+
+export function useFormProgressMachine() {
+  const [snapshot, send] = useMachine(formProgressMachine);
+  return { snapshot, send };
+}

--- a/src/features/hooks/use-title-focus.test.tsx
+++ b/src/features/hooks/use-title-focus.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { useTitleFocus } from './use-title-focus';
+
+describe('useTitleFocus', () => {
+  it('focuses the element on mount', () => {
+    const focusSpy = vi.fn();
+
+    function TestComponent() {
+      const ref = useTitleFocus<HTMLInputElement>();
+
+      return (
+        <input
+          ref={(node) => {
+            if (node) {
+              node.focus = focusSpy;
+            }
+            ref(node);
+          }}
+          data-testid="input"
+        />
+      );
+    }
+
+    render(<TestComponent />);
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw if ref is null', () => {
+    function TestComponent() {
+      const ref = useTitleFocus<HTMLInputElement>();
+
+      return <input ref={ref} data-testid="input" />;
+    }
+
+    expect(() => render(<TestComponent />)).not.toThrow();
+  });
+
+  it('cleans up correctly on unmount', () => {
+    const focusSpy = vi.fn();
+
+    function TestComponent() {
+      const ref = useTitleFocus<HTMLInputElement>();
+
+      return (
+        <input
+          ref={(node) => {
+            if (node) {
+              node.focus = focusSpy;
+            }
+            ref(node);
+          }}
+        />
+      );
+    }
+
+    const { unmount } = render(<TestComponent />);
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+
+    // Should not throw on unmount (cleanup runs)
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it('does NOT focus if element appears after mount', () => {
+    const focusSpy = vi.fn();
+
+    function TestComponent() {
+      const [show, setShow] = useState(false);
+      const ref = useTitleFocus<HTMLInputElement>();
+
+      return (
+        <>
+          <button onClick={() => setShow(true)}>show</button>
+          {show && (
+            <input
+              ref={(node) => {
+                if (node) {
+                  node.focus = focusSpy;
+                }
+                ref(node);
+              }}
+            />
+          )}
+        </>
+      );
+    }
+
+    render(<TestComponent />);
+
+    // Trigger element mount AFTER initial render
+    screen.getByText('show').click();
+
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+
+  it('works with different element types', () => {
+    const focusSpy = vi.fn();
+
+    function TestComponent() {
+      const ref = useTitleFocus<HTMLButtonElement>();
+
+      return (
+        <button
+          ref={(node) => {
+            if (node) {
+              node.focus = focusSpy;
+            }
+            ref(node);
+          }}
+        >
+          Click
+        </button>
+      );
+    }
+
+    render(<TestComponent />);
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/hooks/use-title-focus.ts
+++ b/src/features/hooks/use-title-focus.ts
@@ -8,7 +8,7 @@ export function useTitleFocus<T extends HTMLElement>() {
     if (titleRef.current.kind === 'Some') {
       titleRef.current.value.focus();
     }
-  });
+  }, []);
 
   function refCallback(node: T | null) {
     titleRef.current = nullishToMaybe(node);

--- a/src/features/hooks/use-title-focus.ts
+++ b/src/features/hooks/use-title-focus.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+import { none, nullishToMaybe, type Maybe } from '../../utils';
+
+export function useTitleFocus<T extends HTMLElement>() {
+  const titleRef = useRef<Maybe<T>>(none());
+
+  useEffect(() => {
+    if (titleRef.current.kind === 'Some') {
+      titleRef.current.value.focus();
+    }
+  });
+
+  function refCallback(node: T | null) {
+    titleRef.current = nullishToMaybe(node);
+
+    return () => {
+      titleRef.current = none();
+    };
+  }
+
+  return refCallback;
+}

--- a/src/features/signup-form/add-ons/add-ons.tsx
+++ b/src/features/signup-form/add-ons/add-ons.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useTitleFocus } from '../../hooks/use-title-focus';
 
 type AddOnsProps = {
   options: ReactNode;
@@ -6,10 +7,14 @@ type AddOnsProps = {
 };
 
 export default function AddOns({ options, footer }: AddOnsProps) {
+  const titleRefCallback = useTitleFocus<HTMLLegendElement>();
+
   return (
     <fieldset className="space-y-4">
       <div className="space-y-2">
-        <legend className="text-xl">Pick add-ons</legend>
+        <legend tabIndex={-1} className="text-xl outline-none" ref={titleRefCallback}>
+          Pick add-ons
+        </legend>
         <p className="text-black/45">Add-ons help enhance your gaming experience.</p>
       </div>
 

--- a/src/features/signup-form/select-plan/select-plan.tsx
+++ b/src/features/signup-form/select-plan/select-plan.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useTitleFocus } from '../../hooks/use-title-focus';
 
 type SelectPlanProps = {
   billingOptions: ReactNode;
@@ -11,10 +12,14 @@ export default function SelectPlan({
   subscriptionOptions,
   footer,
 }: SelectPlanProps) {
+  const titleRefCallback = useTitleFocus<HTMLLegendElement>();
+
   return (
     <fieldset className="space-y-4">
       <div className="space-y-2">
-        <legend className="text-xl">Select your plan</legend>
+        <legend tabIndex={-1} className="text-xl outline-none" ref={titleRefCallback}>
+          Select your plan
+        </legend>
         <p className="text-black/45">You have the option of monthly or yearly billing.</p>
       </div>
 

--- a/src/features/signup-form/signup-form.tsx
+++ b/src/features/signup-form/signup-form.tsx
@@ -5,5 +5,12 @@ type Props = {
 };
 
 export default function SignupForm({ children }: Props) {
-  return <form className="rounded-2xl border-2 border-gray-200 p-4 shadow-sm">{children}</form>;
+  return (
+    <form
+      className="rounded-2xl border-2 border-gray-200 p-4 shadow-sm"
+      onSubmit={(e) => e.preventDefault()}
+    >
+      {children}
+    </form>
+  );
 }

--- a/src/features/signup-form/summary/summary.tsx
+++ b/src/features/signup-form/summary/summary.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { calculateTotalPrice, getPriceLabel, type BillingPeriod } from '../utils';
+import { useTitleFocus } from '../../hooks/use-title-focus';
 
 export type SummaryProps = {
   subscription: { name: string; billingPeriod: BillingPeriod; price: number };
@@ -14,6 +15,8 @@ export default function Summary({
   onSubscriptionChange,
   footer,
 }: SummaryProps) {
+  const titleRefCallback = useTitleFocus<HTMLHeadingElement>();
+
   const addOnsList = addOns.map((addOn) => (
     <li key={addOn.name} className="flex items-center justify-between">
       <span className="text-black/45">{addOn.name}</span>
@@ -31,7 +34,9 @@ export default function Summary({
   return (
     <section className="space-y-4">
       <div className="space-y-2">
-        <h2 className="text-xl">Finishing up</h2>
+        <h2 tabIndex={-1} className="text-xl outline-none" ref={titleRefCallback}>
+          Finishing up
+        </h2>
         <p className="text-black/45">Double-check everything looks OK before confirming.</p>
       </div>
 

--- a/src/features/signup-form/your-info/your-info.tsx
+++ b/src/features/signup-form/your-info/your-info.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
+import { useTitleFocus } from '../../hooks/use-title-focus';
 
 type YourInfoProps = {
   inputs: ReactNode;
@@ -6,10 +7,14 @@ type YourInfoProps = {
 };
 
 export default function YourInfo({ inputs, footer }: YourInfoProps) {
+  const titleRefCallback = useTitleFocus<HTMLLegendElement>();
+
   return (
     <fieldset className="space-y-4">
       <div className="space-y-2">
-        <legend className="text-xl">Personal info</legend>
+        <legend tabIndex={-1} className="text-xl outline-none" ref={titleRefCallback}>
+          Personal info
+        </legend>
         <p className="text-black/45">Please provide your name, email address, and phone number.</p>
       </div>
 

--- a/src/features/state/form-progress-state.test.ts
+++ b/src/features/state/form-progress-state.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { createActor } from 'xstate';
+import { formProgressMachine } from './form-progress-state';
+
+describe('formProgressMachine', () => {
+  const getActor = () => createActor(formProgressMachine);
+
+  it('should start in yourInfo with correct initial statusRecord', () => {
+    const actor = getActor();
+    actor.start();
+
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.value).toBe('yourInfo');
+    expect(snapshot.context.statusRecord).toEqual({
+      'your-info': 'Started',
+      'select-plan': 'NotStarted',
+      'add-ons': 'NotStarted',
+      summary: 'NotStarted',
+    });
+  });
+
+  it('should NOT transition if YOUR_INFO.NEXT guard fails', () => {
+    const actor = getActor();
+    actor.start();
+
+    actor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: false });
+
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.value).toBe('yourInfo');
+    expect(snapshot.context.statusRecord['your-info']).toBe('Started');
+  });
+
+  it('should transition to selectPlan when YOUR_INFO.NEXT is valid', () => {
+    const actor = getActor();
+    actor.start();
+
+    actor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: true });
+
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.value).toBe('selectPlan');
+    expect(snapshot.context.statusRecord).toEqual({
+      'your-info': 'Completed',
+      'select-plan': 'Started',
+      'add-ons': 'NotStarted',
+      summary: 'NotStarted',
+    });
+  });
+
+  it('should go back to yourInfo from selectPlan', () => {
+    const actor = getActor();
+    actor.start();
+
+    actor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: true });
+    actor.send({ type: 'SELECT_PLAN.BACK' });
+
+    expect(actor.getSnapshot().value).toBe('yourInfo');
+  });
+
+  it('should transition to addOns and update status', () => {
+    const actor = getActor();
+    actor.start();
+
+    actor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: true });
+    actor.send({ type: 'SELECT_PLAN.NEXT' });
+
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.value).toBe('addOns');
+    expect(snapshot.context.statusRecord).toEqual({
+      'your-info': 'Completed',
+      'select-plan': 'Completed',
+      'add-ons': 'Started',
+      summary: 'NotStarted',
+    });
+  });
+
+  it('should handle ADD_ONS.BACK correctly', () => {
+    const actor = getActor();
+    actor.start();
+
+    actor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: true });
+    actor.send({ type: 'SELECT_PLAN.NEXT' });
+    actor.send({ type: 'ADD_ONS.BACK' });
+
+    expect(actor.getSnapshot().value).toBe('selectPlan');
+  });
+
+  it('should transition to summary and update status', () => {
+    const actor = getActor();
+    actor.start();
+
+    actor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: true });
+    actor.send({ type: 'SELECT_PLAN.NEXT' });
+    actor.send({ type: 'ADD_ONS.NEXT' });
+
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.value).toBe('summary');
+    expect(snapshot.context.statusRecord).toEqual({
+      'your-info': 'Completed',
+      'select-plan': 'Completed',
+      'add-ons': 'Completed',
+      summary: 'Started',
+    });
+  });
+
+  it('should go back to addOns from summary', () => {
+    const actor = getActor();
+    actor.start();
+
+    actor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: true });
+    actor.send({ type: 'SELECT_PLAN.NEXT' });
+    actor.send({ type: 'ADD_ONS.NEXT' });
+    actor.send({ type: 'SUMMARY.BACK' });
+
+    expect(actor.getSnapshot().value).toBe('addOns');
+  });
+
+  it('should jump to selectPlan on CHANGE_SUBSCRIPTION', () => {
+    const actor = getActor();
+    actor.start();
+
+    actor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: true });
+    actor.send({ type: 'SELECT_PLAN.NEXT' });
+    actor.send({ type: 'ADD_ONS.NEXT' });
+    actor.send({ type: 'SUMMARY.CHANGE_SUBSCRIPTION' });
+
+    expect(actor.getSnapshot().value).toBe('selectPlan');
+  });
+
+  it('should reach confirmation and mark summary as completed', () => {
+    const actor = getActor();
+    actor.start();
+
+    actor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: true });
+    actor.send({ type: 'SELECT_PLAN.NEXT' });
+    actor.send({ type: 'ADD_ONS.NEXT' });
+    actor.send({ type: 'SUMMARY.NEXT' });
+
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.value).toBe('confirmation');
+    expect(snapshot.context.statusRecord.summary).toBe('Completed');
+  });
+
+  it('should be in final state at confirmation', () => {
+    const actor = getActor();
+    actor.start();
+
+    actor.send({ type: 'YOUR_INFO.NEXT', isInfoValid: true });
+    actor.send({ type: 'SELECT_PLAN.NEXT' });
+    actor.send({ type: 'ADD_ONS.NEXT' });
+    actor.send({ type: 'SUMMARY.NEXT' });
+
+    expect(actor.getSnapshot().status).toBe('done');
+  });
+});

--- a/src/features/state/form-progress-state.ts
+++ b/src/features/state/form-progress-state.ts
@@ -73,6 +73,7 @@ export const formProgressMachine = setup({
               params: { 'your-info': 'Completed', 'select-plan': 'Started' },
             },
           ],
+          guard: ({ event }) => event.isInfoValid,
         },
       },
     },

--- a/src/features/state/form-progress-state.ts
+++ b/src/features/state/form-progress-state.ts
@@ -1,0 +1,179 @@
+import { assign, setup } from 'xstate';
+import { none, some, type Maybe } from '../../utils';
+
+type FormStep = { id: string; title: string };
+
+type FormStepStatus = 'Completed' | 'Started' | 'NotStarted';
+
+type StatusRecord = Record<FormStep['id'], FormStepStatus>;
+
+type SideEffect = {
+  kind: 'FocusTitle';
+  titleEl: HTMLHeadingElement | HTMLLegendElement;
+};
+
+type Context = {
+  statusRecord: StatusRecord;
+  maybeSideEffect: Maybe<SideEffect>;
+};
+
+type Events =
+  | { type: 'YOUR_INFO.NEXT'; titleElToFocus: SideEffect['titleEl']; isInfoValid: boolean }
+  | {
+      type:
+        | 'SELECT_PLAN.BACK'
+        | 'SELECT_PLAN.NEXT'
+        | 'ADD_ONS.BACK'
+        | 'ADD_ONS.NEXT'
+        | 'SUMMARY.CHANGE_SUBSCRIPTION'
+        | 'SUMMARY.BACK'
+        | 'SUMMARY.NEXT';
+      titleElToFocus: SideEffect['titleEl'];
+    };
+
+export const formProgressMachine = setup({
+  types: {
+    context: {} as Context,
+    events: {} as Events,
+  },
+
+  actions: {
+    updateStatusRecord: assign({
+      statusRecord: ({ context }, params: StatusRecord) => {
+        return {
+          ...context.statusRecord,
+          ...params,
+        };
+      },
+    }),
+
+    updateSideEffext: assign({
+      maybeSideEffect: (_, params: Maybe<SideEffect>) => {
+        return params;
+      },
+    }),
+  },
+}).createMachine({
+  id: 'form-progress-machine',
+
+  context: {
+    statusRecord: {
+      'your-info': 'NotStarted',
+      'select-plan': 'NotStarted',
+      'add-ons': 'NotStarted',
+      summary: 'NotStarted',
+    },
+
+    maybeSideEffect: none(),
+  },
+
+  initial: 'yourInfo',
+
+  states: {
+    yourInfo: {
+      on: {
+        'YOUR_INFO.NEXT': {
+          target: 'selectPlan',
+          actions: [
+            {
+              type: 'updateStatusRecord',
+              params: { 'your-info': 'Completed', 'select-plan': 'Started' },
+            },
+            {
+              type: 'updateSideEffext',
+              params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
+            },
+          ],
+        },
+      },
+    },
+
+    selectPlan: {
+      on: {
+        'SELECT_PLAN.BACK': {
+          target: 'yourInfo',
+          actions: {
+            type: 'updateSideEffext',
+            params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
+          },
+        },
+
+        'SELECT_PLAN.NEXT': {
+          target: 'addOns',
+          actions: [
+            {
+              type: 'updateStatusRecord',
+              params: { 'select-plan': 'Completed', 'add-ons': 'Started' },
+            },
+            {
+              type: 'updateSideEffext',
+              params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
+            },
+          ],
+        },
+      },
+    },
+
+    addOns: {
+      on: {
+        'ADD_ONS.BACK': {
+          target: 'selectPlan',
+          actions: {
+            type: 'updateSideEffext',
+            params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
+          },
+        },
+
+        'ADD_ONS.NEXT': {
+          target: 'summary',
+          actions: [
+            {
+              type: 'updateStatusRecord',
+              params: { 'add-ons': 'Completed', summary: 'Started' },
+            },
+            {
+              type: 'updateSideEffext',
+              params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
+            },
+          ],
+        },
+      },
+    },
+
+    summary: {
+      on: {
+        'SUMMARY.CHANGE_SUBSCRIPTION': {
+          target: 'selectPlan',
+          actions: {
+            type: 'updateSideEffext',
+            params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
+          },
+        },
+
+        'SUMMARY.BACK': {
+          target: 'addOns',
+          actions: {
+            type: 'updateSideEffext',
+            params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
+          },
+        },
+
+        'SUMMARY.NEXT': {
+          target: 'confirmation',
+          actions: [
+            {
+              type: 'updateStatusRecord',
+              params: { summary: 'Completed' },
+            },
+            {
+              type: 'updateSideEffext',
+              params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
+            },
+          ],
+        },
+      },
+    },
+
+    confirmation: { type: 'final' },
+  },
+});

--- a/src/features/state/form-progress-state.ts
+++ b/src/features/state/form-progress-state.ts
@@ -51,7 +51,7 @@ export const formProgressMachine = setup({
 
   context: {
     statusRecord: {
-      'your-info': 'NotStarted',
+      'your-info': 'Started',
       'select-plan': 'NotStarted',
       'add-ons': 'NotStarted',
       summary: 'NotStarted',

--- a/src/features/state/form-progress-state.ts
+++ b/src/features/state/form-progress-state.ts
@@ -23,6 +23,13 @@ type Events =
         | 'SUMMARY.NEXT';
     };
 
+export const formSteps: Record<FormStep['id'], FormStep> = {
+  'your-info': { id: 'your-info', title: 'Your info' },
+  'select-plan': { id: 'select-plan', title: 'Select plan' },
+  'add-ons': { id: 'add-ons', title: 'Add-ons' },
+  summary: { id: 'summary', title: 'Summary' },
+};
+
 export const formProgressMachine = setup({
   types: {
     context: {} as Context,

--- a/src/features/state/form-progress-state.ts
+++ b/src/features/state/form-progress-state.ts
@@ -55,6 +55,8 @@ export const formProgressMachine = setup({
 
   states: {
     yourInfo: {
+      tags: ['yourInfo'],
+
       on: {
         'YOUR_INFO.NEXT': {
           target: 'selectPlan',
@@ -69,6 +71,8 @@ export const formProgressMachine = setup({
     },
 
     selectPlan: {
+      tags: ['selectPlan'],
+
       on: {
         'SELECT_PLAN.BACK': {
           target: 'yourInfo',
@@ -87,6 +91,8 @@ export const formProgressMachine = setup({
     },
 
     addOns: {
+      tags: ['addOns'],
+
       on: {
         'ADD_ONS.BACK': {
           target: 'selectPlan',
@@ -105,6 +111,8 @@ export const formProgressMachine = setup({
     },
 
     summary: {
+      tags: ['summary'],
+
       on: {
         'SUMMARY.CHANGE_SUBSCRIPTION': {
           target: 'selectPlan',
@@ -126,6 +134,6 @@ export const formProgressMachine = setup({
       },
     },
 
-    confirmation: { type: 'final' },
+    confirmation: { tags: ['confirmation'], type: 'final' },
   },
 });

--- a/src/features/state/form-progress-state.ts
+++ b/src/features/state/form-progress-state.ts
@@ -30,6 +30,12 @@ export const formSteps: Record<FormStep['id'], FormStep> = {
   summary: { id: 'summary', title: 'Summary' },
 };
 
+export const formStepStatusDescriptions: Record<FormStepStatus, string> = {
+  Completed: 'Completed',
+  NotStarted: 'Not started',
+  Started: 'Started',
+};
+
 export const formProgressMachine = setup({
   types: {
     context: {} as Context,

--- a/src/features/state/form-progress-state.ts
+++ b/src/features/state/form-progress-state.ts
@@ -1,5 +1,4 @@
 import { assign, setup } from 'xstate';
-import { none, some, type Maybe } from '../../utils';
 
 type FormStep = { id: string; title: string };
 
@@ -7,18 +6,12 @@ type FormStepStatus = 'Completed' | 'Started' | 'NotStarted';
 
 type StatusRecord = Record<FormStep['id'], FormStepStatus>;
 
-type SideEffect = {
-  kind: 'FocusTitle';
-  titleEl: HTMLHeadingElement | HTMLLegendElement;
-};
-
 type Context = {
   statusRecord: StatusRecord;
-  maybeSideEffect: Maybe<SideEffect>;
 };
 
 type Events =
-  | { type: 'YOUR_INFO.NEXT'; titleElToFocus: SideEffect['titleEl']; isInfoValid: boolean }
+  | { type: 'YOUR_INFO.NEXT'; isInfoValid: boolean }
   | {
       type:
         | 'SELECT_PLAN.BACK'
@@ -28,7 +21,6 @@ type Events =
         | 'SUMMARY.CHANGE_SUBSCRIPTION'
         | 'SUMMARY.BACK'
         | 'SUMMARY.NEXT';
-      titleElToFocus: SideEffect['titleEl'];
     };
 
 export const formProgressMachine = setup({
@@ -46,12 +38,6 @@ export const formProgressMachine = setup({
         };
       },
     }),
-
-    updateSideEffext: assign({
-      maybeSideEffect: (_, params: Maybe<SideEffect>) => {
-        return params;
-      },
-    }),
   },
 }).createMachine({
   id: 'form-progress-machine',
@@ -63,8 +49,6 @@ export const formProgressMachine = setup({
       'add-ons': 'NotStarted',
       summary: 'NotStarted',
     },
-
-    maybeSideEffect: none(),
   },
 
   initial: 'yourInfo',
@@ -79,10 +63,6 @@ export const formProgressMachine = setup({
               type: 'updateStatusRecord',
               params: { 'your-info': 'Completed', 'select-plan': 'Started' },
             },
-            {
-              type: 'updateSideEffext',
-              params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
-            },
           ],
         },
       },
@@ -92,10 +72,6 @@ export const formProgressMachine = setup({
       on: {
         'SELECT_PLAN.BACK': {
           target: 'yourInfo',
-          actions: {
-            type: 'updateSideEffext',
-            params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
-          },
         },
 
         'SELECT_PLAN.NEXT': {
@@ -104,10 +80,6 @@ export const formProgressMachine = setup({
             {
               type: 'updateStatusRecord',
               params: { 'select-plan': 'Completed', 'add-ons': 'Started' },
-            },
-            {
-              type: 'updateSideEffext',
-              params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
             },
           ],
         },
@@ -118,10 +90,6 @@ export const formProgressMachine = setup({
       on: {
         'ADD_ONS.BACK': {
           target: 'selectPlan',
-          actions: {
-            type: 'updateSideEffext',
-            params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
-          },
         },
 
         'ADD_ONS.NEXT': {
@@ -130,10 +98,6 @@ export const formProgressMachine = setup({
             {
               type: 'updateStatusRecord',
               params: { 'add-ons': 'Completed', summary: 'Started' },
-            },
-            {
-              type: 'updateSideEffext',
-              params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
             },
           ],
         },
@@ -144,18 +108,10 @@ export const formProgressMachine = setup({
       on: {
         'SUMMARY.CHANGE_SUBSCRIPTION': {
           target: 'selectPlan',
-          actions: {
-            type: 'updateSideEffext',
-            params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
-          },
         },
 
         'SUMMARY.BACK': {
           target: 'addOns',
-          actions: {
-            type: 'updateSideEffext',
-            params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
-          },
         },
 
         'SUMMARY.NEXT': {
@@ -164,10 +120,6 @@ export const formProgressMachine = setup({
             {
               type: 'updateStatusRecord',
               params: { summary: 'Completed' },
-            },
-            {
-              type: 'updateSideEffext',
-              params: ({ event }) => some({ kind: 'FocusTitle', titleEl: event.titleElToFocus }),
             },
           ],
         },


### PR DESCRIPTION
## 📌 Description

Add state management for form progress.

Closes #27.

---

## 🔧 Changes Made

- Added form progress state machine (and tests).
- Added `useTitleFocus` hook (and tests).

---

## 🧪 How to Test

1. Pull this branch.
2. Run tests: `bun run test`.
3. Run the application.
4. Try navigating across different form steps.

---

## ✅ Checklist

- [X] Code compiles and runs
- [X] Tested locally